### PR TITLE
fix: Group trash and minor bug

### DIFF
--- a/src/components/features/CreateGroup.tsx
+++ b/src/components/features/CreateGroup.tsx
@@ -66,7 +66,7 @@ export function CreateGroup({ onCreate }: CreateGroupProps) {
           Create Group
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md" onKeyDown={(e) => e.stopPropagation()}>
         <Form {...form}>
           <form
             onSubmit={(e) => {
@@ -90,7 +90,7 @@ export function CreateGroup({ onCreate }: CreateGroupProps) {
                   <FormItem>
                     <FormLabel>Name</FormLabel>
                     <FormControl>
-                      <Input placeholder="Group name" {...field} />
+                      <Input autoComplete="off" placeholder="Group name" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/features/CreateSimulation.tsx
+++ b/src/components/features/CreateSimulation.tsx
@@ -24,7 +24,10 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
-import { useCreateSimulationMutation } from "@/store/simulationApi";
+import {
+  useCreateSimulationMutation,
+  useLazyGetSimulationsByModelIdQuery,
+} from "@/store/simulationApi";
 import { toast } from "sonner";
 import { useNavigate } from "react-router";
 
@@ -49,6 +52,7 @@ export function CreateSimulation({ modelId }: CreateSimulationProps) {
     },
   });
   const [createSimulation, { isLoading }] = useCreateSimulationMutation();
+  const [getSimulationsByModelId] = useLazyGetSimulationsByModelIdQuery();
 
   // Reset form when dialog closes
   useEffect(() => {
@@ -67,6 +71,10 @@ export function CreateSimulation({ modelId }: CreateSimulationProps) {
           simulationSettings: {},
         },
       }).unwrap();
+
+      // Refetch simulations to update the list
+      await getSimulationsByModelId(modelId).unwrap();
+
       navigate(`/editor/${modelId}/${result.id}`);
       toast.success("Simulation created successfully");
       setOpen(false);

--- a/src/components/features/DeleteGroup.tsx
+++ b/src/components/features/DeleteGroup.tsx
@@ -54,8 +54,12 @@ export function DeleteGroup({ group, projectsCount }: DeleteGroupProps) {
           : `Are you sure you want to delete group "${group}"? This action cannot be undone.`
       }
       trigger={
-        <Button variant="ghost" size="sm">
-          <TrashIcon className="size-4 text-destructive" />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="opacity-25 hover:opacity-75 hover:bg-transparent transition-opacity"
+        >
+          <TrashIcon className="size-4 text-black" />
         </Button>
       }
       open={open}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -72,14 +72,15 @@ export function HomePage() {
         </div>
         {groupProjects.map((groupProject) => (
           <div key={groupProject.group}>
-            <h1 className="inline pb-2 text-lg font-inter font-light border-b text-choras-dark border-b-choras-dark">
-              {groupProject.group === "NONE" ? "Ungrouped" : groupProject.group}
-
+            <div className="flex items-center">
+              <h1 className="inline text-lg font-inter font-light border-b text-choras-dark border-b-choras-dark">
+                {groupProject.group === "NONE" ? "Ungrouped" : groupProject.group}
+              </h1>
               <DeleteGroup
                 projectsCount={groupProject.projects.length}
                 group={groupProject.group}
               />
-            </h1>
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 border-b border-b-black/25 mt-5 pb-8 mb-6">
               {groupProject.projects.map((project) => (
                 <Link key={project.id} to={`/projects/${project.id}`}>

--- a/src/store/simulationApi.ts
+++ b/src/store/simulationApi.ts
@@ -7,7 +7,7 @@ export const simulationApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: import.meta.env.VITE_API_URL }),
 
   // Define tag types for cache invalidation
-  tagTypes: ["Simulations"],
+  tagTypes: ["Simulations", "SimulationsByModel"],
 
   endpoints: (build) => ({
     // Get all simulations
@@ -15,7 +15,7 @@ export const simulationApi = createApi({
       query: (modelId) => `/simulations?modelId=${modelId}`,
 
       // Provides a list of Simulations-type tags for cache invalidation
-      providesTags: (_, __, arg) => [{ type: "Simulations", id: arg }],
+      providesTags: (_, __, arg) => [{ type: "SimulationsByModel", id: arg }],
     }),
 
     createSimulation: build.mutation<Simulation, Partial<Simulation>>({
@@ -26,7 +26,7 @@ export const simulationApi = createApi({
       }),
 
       // Invalidates Simulations-type tags to refetch relevant queries
-      invalidatesTags: (_, __, arg) => [{ type: "Simulations", id: arg.modelId }],
+      invalidatesTags: (_, __, arg) => [{ type: "SimulationsByModel", id: arg.modelId }],
     }),
 
     // Get simulation by ID
@@ -48,7 +48,7 @@ export const simulationApi = createApi({
       // Invalidates specific simulation and list tags
       invalidatesTags: (_, __, arg) => [
         { type: "Simulations", id: arg.id },
-        { type: "Simulations", id: arg.body.modelId },
+        { type: "SimulationsByModel", id: arg.body.modelId },
       ],
     }),
   }),
@@ -58,6 +58,7 @@ export const simulationApi = createApi({
 // auto-generated based on the defined endpoints
 export const {
   useGetSimulationsByModelIdQuery,
+  useLazyGetSimulationsByModelIdQuery,
   useCreateSimulationMutation,
   useGetSimulationByIdQuery,
   useUpdateSimulationMutation,


### PR DESCRIPTION
## Changelog

- Fix: The trashcan doesn't have to be so obvious (perhaps black with 50% opacity, and 75% on hover?) Also the underline only has to go underneath the text, not the trashcan, and can also be 50% opacity.
- Fix: When I want to create a new group and start typing the name of an existing group, I can't seem to type it (see [video](https://github.com/user-attachments/assets/7ba37757-4e64-4703-9862-8de9a9f8d6c9)). Also my password manager seems to recognise many input boxes as "username" or "password" boxes. I'm not sure how this works, but do you think this can be disabled?
- Fix: After creating a new simulation, this is not automatically reflected in the SimulationPicker dropdown. Could this be implemented?