### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.14](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.13...v0.0.14) (2025-10-19)
+
+### Bug Fixes
+
+- change debounce value for update settings to 1 second instead of 300ms ([55904a7](https://github.com/ajatdarojat45/frontend-v2/commit/55904a738f5fdb96a81695b52a4427bbc8469390))
+- different validation type for source and receiver when close together ([554b20d](https://github.com/ajatdarojat45/frontend-v2/commit/554b20d6ae87cd61f4d247fcda985a7a6f122c9e))
+- make source&receivers turns red in viewport when not valid ([6dd6d41](https://github.com/ajatdarojat45/frontend-v2/commit/6dd6d41e85604e553547b5802565273ee89ce390))
+- only register click event to (de)select sources/receivers ([968cd81](https://github.com/ajatdarojat45/frontend-v2/commit/968cd811867f28fa02b4401bead5adac16ec2757))
+- prevent rendering when there are no projects in "NONE" group ([e605ced](https://github.com/ajatdarojat45/frontend-v2/commit/e605ceda06886ded355fe37c9e260d20fa826ab4))
+- settings validation to not exceed the range input and not call update ([43b2e28](https://github.com/ajatdarojat45/frontend-v2/commit/43b2e28c96df76f30b4b97265e6ff340f860d3af))
+
 ### [0.0.13](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.12...v0.0.13) (2025-10-18)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/DynamicSettingField.tsx
+++ b/src/components/features/simulationSettings/DynamicSettingField.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { SimulationSettingOption } from "@/types/simulationSettings";
@@ -5,11 +6,45 @@ import type { SimulationSettingOption } from "@/types/simulationSettings";
 interface DynamicSettingFieldProps {
   option: SimulationSettingOption;
   value: string | number;
-  onChange: (value: string | number) => void;
+  onChange: (value: string | number, isValid?: boolean) => void;
 }
 
 export function DynamicSettingField({ option, value, onChange }: DynamicSettingFieldProps) {
   const { id, name, type, display, min, max, step, startAdornment, endAdornment, options } = option;
+  const [localValue, setLocalValue] = useState(String(value));
+  const [isValid, setIsValid] = useState(true);
+
+  useEffect(() => {
+    setLocalValue(String(value));
+  }, [value]);
+
+  const validateValue = (inputValue: string | number): boolean => {
+    if (type === "string") return true;
+
+    const numValue = typeof inputValue === "string" ? parseFloat(inputValue) : inputValue;
+    if (isNaN(numValue)) return false;
+
+    if (min !== undefined && numValue < min) return false;
+    if (max !== undefined && numValue > max) return false;
+
+    return true;
+  };
+
+  const handleInputChange = (inputValue: string) => {
+    setLocalValue(inputValue);
+
+    if (type === "string") {
+      onChange(inputValue, true);
+      setIsValid(true);
+      return;
+    }
+
+    const numValue = type === "integer" ? parseInt(inputValue) || 0 : parseFloat(inputValue) || 0;
+    const valid = validateValue(numValue);
+    setIsValid(valid);
+
+    onChange(numValue, valid);
+  };
 
   const renderField = (
     labelContent: React.ReactNode,
@@ -40,7 +75,7 @@ export function DynamicSettingField({ option, value, onChange }: DynamicSettingF
             <div key={stringValue} className="flex items-center space-x-2">
               <button
                 type="button"
-                onClick={() => onChange(stringValue)}
+                onClick={() => onChange(stringValue, true)}
                 className={`w-4 h-4 rounded-full border-2 transition-all ${
                   isSelected
                     ? "border-white bg-transparent"
@@ -51,7 +86,7 @@ export function DynamicSettingField({ option, value, onChange }: DynamicSettingF
               </button>
               <Label
                 className="text-xs text-gray-300 cursor-pointer"
-                onClick={() => onChange(stringValue)}
+                onClick={() => onChange(stringValue, true)}
               >
                 {label}
               </Label>
@@ -84,22 +119,18 @@ export function DynamicSettingField({ option, value, onChange }: DynamicSettingF
         <Input
           id={id}
           type={inputType}
-          value={value}
-          onChange={(e) => {
-            const newValue =
-              type === "string"
-                ? e.target.value
-                : type === "integer"
-                  ? parseInt(e.target.value) || 0
-                  : parseFloat(e.target.value) || 0;
-            onChange(newValue);
-          }}
+          value={localValue}
+          onChange={(e) => handleInputChange(e.target.value)}
           min={min}
           max={max}
           step={stepValue}
-          className={`bg-gray-800 border-gray-600 text-white ${
+          className={`bg-gray-800 text-white transition-colors ${
             startAdornment ? "pl-12" : ""
-          } ${endAdornment ? "pr-12" : ""}`}
+          } ${endAdornment ? "pr-12" : ""} ${
+            isValid
+              ? "border-gray-600 focus:border-blue-500"
+              : "border-red-500 focus:border-red-400"
+          }`}
         />
         {endAdornment && (
           <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-xs text-gray-400">
@@ -111,7 +142,7 @@ export function DynamicSettingField({ option, value, onChange }: DynamicSettingF
 
     const extraContent =
       min !== undefined || max !== undefined ? (
-        <div className="text-xs text-gray-500">
+        <div className={`text-xs ${isValid ? "text-gray-500" : "text-red-400"}`}>
           {min !== undefined && max !== undefined
             ? `Range: ${min} - ${max}`
             : min !== undefined

--- a/src/components/features/simulationSettings/SettingJsonEditor.tsx
+++ b/src/components/features/simulationSettings/SettingJsonEditor.tsx
@@ -8,7 +8,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { EllipsisVertical } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Editor } from "@monaco-editor/react";
@@ -105,7 +104,6 @@ export function SettingJsonEditor() {
 
       await updateSimulationSettings(parsedJson);
 
-      toast.success("Settings saved successfully");
       setOpen(false);
     } catch (error) {
       console.error("Failed to save JSON settings:", error);
@@ -116,8 +114,12 @@ export function SettingJsonEditor() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="ghost" className="rounded-full hover:bg-gray-600 hover:text-white">
-          <EllipsisVertical size={20} className="text-white" />
+        <Button
+          variant="ghost"
+          size={"sm"}
+          className="hover:bg-gray-600 hover:text-white border border-choras-gray rounded-lg"
+        >
+          Open as JSON
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-2xl max-h-[80vh]">
@@ -158,14 +160,14 @@ export function SettingJsonEditor() {
           <Button
             variant="outline"
             onClick={handleReset}
-            className="text-gray-300 border-gray-600 hover:bg-gray-700"
+            className="border-choras-primary cursor-pointer"
           >
             Reset
           </Button>
           <Button
             onClick={handleSave}
             disabled={!isValidJson}
-            className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600"
+            className="bg-choras-primary disabled:bg-gray-600 cursor-pointer disabled:cursor-not-allowed"
           >
             Save
           </Button>

--- a/src/components/features/simulationSettings/SettingTab.tsx
+++ b/src/components/features/simulationSettings/SettingTab.tsx
@@ -48,11 +48,12 @@ export function SettingTab() {
     }
   }, [simulation?.id, settingsData?.options, dispatch]);
 
-  const handleValueChange = (id: string, value: string | number) => {
-    dispatch(updateValue({ id, value }));
-
-    const updatedValues = { ...values, [id]: value };
-    updateSimulationSettings(updatedValues);
+  const handleValueChange = (id: string, value: string | number, isValid: boolean = true) => {
+    if (isValid) {
+      dispatch(updateValue({ id, value }));
+      const updatedValues = { ...values, [id]: value };
+      updateSimulationSettings(updatedValues);
+    }
   };
 
   const generalSettingsIds = ["de_c0", "de_ir_length", "sim_len_type"];
@@ -112,7 +113,7 @@ export function SettingTab() {
                   key={option.id}
                   option={option}
                   value={values[option.id] || option.default}
-                  onChange={(value) => handleValueChange(option.id, value)}
+                  onChange={(value, isValid) => handleValueChange(option.id, value, isValid)}
                 />
               ))}
               {generalSettings.length === 0 && (
@@ -143,7 +144,7 @@ export function SettingTab() {
                   key={option.id}
                   option={option}
                   value={values[option.id] || option.default}
-                  onChange={(value) => handleValueChange(option.id, value)}
+                  onChange={(value, isValid) => handleValueChange(option.id, value, isValid)}
                 />
               ))}
               {extendedSettings.length === 0 && (

--- a/src/components/features/simulationSettings/SettingTab.tsx
+++ b/src/components/features/simulationSettings/SettingTab.tsx
@@ -63,8 +63,8 @@ export function SettingTab() {
   if (isLoading) {
     return (
       <div className="text-white">
-        <div className="mb-4">
-          <h4 className="text-lg font-semibold mb-2">Settings</h4>
+        <div className="mb-4 mt-2 flex justify-between items-center">
+          <h4 className="text-xl text-choras-primary">Settings</h4>
         </div>
         <div className="flex items-center justify-center py-8">
           <div className="text-gray-400">Loading settings...</div>
@@ -76,8 +76,8 @@ export function SettingTab() {
   if (error || simulationError) {
     return (
       <div className="text-white">
-        <div className="mb-4">
-          <h4 className="text-lg font-semibold mb-2">Settings</h4>
+        <div className="mb-4 mt-2 flex justify-between items-center">
+          <h4 className="text-xl text-choras-primary">Settings</h4>
         </div>
         <div className="flex items-center justify-center py-8">
           <div className="text-red-400">Failed to load simulation settings</div>
@@ -88,7 +88,7 @@ export function SettingTab() {
 
   return (
     <div className="text-white">
-      <div className="mb-4 flex justify-between items-center">
+      <div className="mb-4 mt-2 flex justify-between items-center">
         <h4 className="text-xl text-choras-primary">Settings</h4>
         <SettingJsonEditor />
       </div>

--- a/src/components/features/simulationSettings/SettingTab.tsx
+++ b/src/components/features/simulationSettings/SettingTab.tsx
@@ -89,7 +89,7 @@ export function SettingTab() {
   return (
     <div className="text-white">
       <div className="mb-4 flex justify-between items-center">
-        <h4 className="text-xl text-choras-primary">Sources</h4>
+        <h4 className="text-xl text-choras-primary">Settings</h4>
         <SettingJsonEditor />
       </div>
 

--- a/src/components/features/simulationSettings/SourceReceiversTab.tsx
+++ b/src/components/features/simulationSettings/SourceReceiversTab.tsx
@@ -45,6 +45,8 @@ export function SourceReceiversTab() {
       modelBounds,
       sources,
       surfaces,
+      receiver.id,
+      "receiver",
     );
 
     return {
@@ -56,13 +58,13 @@ export function SourceReceiversTab() {
 
   const validateSource = (source: Source): Source => {
     const modelBounds = getModelBounds(surfaces);
-    const allOtherPoints = [...sources.filter((s) => s.id !== source.id), ...receivers];
     const validation = validateSourceOrReceiver(
       { x: source.x, y: source.y, z: source.z },
       modelBounds,
-      allOtherPoints,
+      receivers,
       surfaces,
       source.id,
+      "source",
     );
 
     return {

--- a/src/components/features/viewport/ReceiverVisualization.tsx
+++ b/src/components/features/viewport/ReceiverVisualization.tsx
@@ -61,13 +61,13 @@ function ReceiverPoint({
         }}
       >
         <sphereGeometry args={[0.15, 16, 16]} />
-        <meshBasicMaterial color={"#eab308"} />
+        <meshBasicMaterial color={receiver.isValid === false ? "#ef4444" : "#eab308"} />
       </mesh>
 
       <Text
         position={[receiver.x, receiver.y, receiver.z + 0.3]}
         fontSize={0.2}
-        color={"#eab308"}
+        color={receiver.isValid === false ? "#dc2626" : "#eab308"}
         anchorX="center"
         anchorY="middle"
         outlineWidth={0.02}

--- a/src/components/features/viewport/SourceVisualization.tsx
+++ b/src/components/features/viewport/SourceVisualization.tsx
@@ -61,13 +61,13 @@ function SourcePoint({
         }}
       >
         <sphereGeometry args={[0.15, 16, 16]} />
-        <meshBasicMaterial color={"#22d3ee"} />
+        <meshBasicMaterial color={source.isValid === false ? "#ef4444" : "#22d3ee"} />
       </mesh>
 
       <Text
         position={[source.x, source.y, source.z + 0.3]}
         fontSize={0.2}
-        color={"#06b6d4"}
+        color={source.isValid === false ? "#dc2626" : "#06b6d4"}
         anchorX="center"
         anchorY="middle"
         outlineWidth={0.02}

--- a/src/helpers/sourceReceiverValidation.ts
+++ b/src/helpers/sourceReceiverValidation.ts
@@ -22,9 +22,10 @@ const INVISIBLE_SPHERE_RADIUS = 0.2;
 export function validateSourceOrReceiver(
   point: Point3D,
   modelBounds: ModelBounds,
-  sources: Source[],
+  otherPoints: (Source | { x: number; y: number; z: number; id: string })[],
   surfaces: SurfaceInfo[],
-  excludeSourceId?: string,
+  excludeId?: string,
+  pointType?: "source" | "receiver",
 ): ValidationResult {
   // Check if point is outside the model bounds (x <= 0 case)
   if (
@@ -50,15 +51,18 @@ export function validateSourceOrReceiver(
     }
   }
 
-  for (const source of sources) {
-    if (excludeSourceId && source.id === excludeSourceId) {
+  for (const otherPoint of otherPoints) {
+    if (excludeId && otherPoint.id === excludeId) {
       continue;
     }
 
-    if (isPointTooCloseToPoint(point, source)) {
+    if (isPointTooCloseToPoint(point, otherPoint)) {
+      // Determine the appropriate error message based on what we're validating against
+      const errorMessage =
+        pointType === "source" ? "Too close to a receiver" : "Too close to a source";
       return {
         isValid: false,
-        validationError: "too close to a source",
+        validationError: errorMessage,
       };
     }
   }

--- a/src/hooks/useSimulationSettingsApi.ts
+++ b/src/hooks/useSimulationSettingsApi.ts
@@ -67,7 +67,7 @@ export function useSimulationSettingsApi() {
           console.error("Failed to update simulation:", error);
           toast.error("Failed to save settings");
         }
-      }, 300);
+      }, 1000);
     },
     [activeSimulation?.id, simulation, currentModelId, values, updateSimulation],
   );


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the simulation settings and viewport interaction logic. The main focus is on enhancing validation feedback for settings, improving user experience when interacting with sources and receivers in the viewport, and refining the UI for better clarity and usability.

**Validation and Settings Improvements:**

* Added real-time validation to `DynamicSettingField`, including range checks and visual feedback (red borders and text for invalid values), and updated its `onChange` signature to include validity information. [[1]](diffhunk://#diff-20577d3822f2bed40c89a6972af14d81b35b9b042c48cb27868bbdc2dd0a07a2R1-R47) [[2]](diffhunk://#diff-20577d3822f2bed40c89a6972af14d81b35b9b042c48cb27868bbdc2dd0a07a2L43-R78) [[3]](diffhunk://#diff-20577d3822f2bed40c89a6972af14d81b35b9b042c48cb27868bbdc2dd0a07a2L54-R89) [[4]](diffhunk://#diff-20577d3822f2bed40c89a6972af14d81b35b9b042c48cb27868bbdc2dd0a07a2L87-R133) [[5]](diffhunk://#diff-20577d3822f2bed40c89a6972af14d81b35b9b042c48cb27868bbdc2dd0a07a2L114-R145)
* Updated `SettingTab` to only dispatch and update simulation settings when values are valid, and passed validation state from setting fields. [[1]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L51-R56) [[2]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L115-R116) [[3]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L146-R147)
* Changed the JSON editor button to be more descriptive ("Open as JSON") and improved button styling for both the JSON editor and Save/Reset actions. Removed a redundant success toast on save. [[1]](diffhunk://#diff-ad7600598d83d0998444dbd6011b55a0c1902a8bde89a1d9d65d57878e3d02e5L11) [[2]](diffhunk://#diff-ad7600598d83d0998444dbd6011b55a0c1902a8bde89a1d9d65d57878e3d02e5L108) [[3]](diffhunk://#diff-ad7600598d83d0998444dbd6011b55a0c1902a8bde89a1d9d65d57878e3d02e5L119-R122) [[4]](diffhunk://#diff-ad7600598d83d0998444dbd6011b55a0c1902a8bde89a1d9d65d57878e3d02e5L161-R170)

**Viewport Interaction Enhancements:**

* Improved click and drag handling in the model viewport: now distinguishes between drag and click events to prevent accidental selection/deselection of sources/receivers during drag operations. [[1]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8R11) [[2]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8R36-R37) [[3]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8L91-R128) [[4]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8L123-R179) [[5]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8R243) [[6]](diffhunk://#diff-29d638138c78e1dcbf534b764425eea1b83dca52523ee79c083b9727be3d5cc8L210-R260)
* Updated source and receiver validation logic to use distinct validation types and ensure correct feedback when sources and receivers are close together. [[1]](diffhunk://#diff-831636422fa4e8f815cfbb85ab2486767cbd81a0941e337e99c3ea91e7e6acc7R48-R49) [[2]](diffhunk://#diff-831636422fa4e8f815cfbb85ab2486767cbd81a0941e337e99c3ea91e7e6acc7L59-R67)
* Made invalid sources and receivers visually distinct in the viewport by changing their colors to red when not valid. [[1]](diffhunk://#diff-4c9f8a68a9a2c4652d07f68433137e03b70c85b59f5c587b902ccc664804f7edL64-R70) [[2]](diffhunk://#diff-54feefaa3248d1fd48b54ecd5faff6bd259b14330726e5e9ed4e2a0830a754d6L64-R70)

**UI/UX Refinements:**

* Improved section headers and layout in the settings tab for better clarity and consistency. [[1]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L65-R67) [[2]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L78-R80) [[3]](diffhunk://#diff-7c4702cc2b91babbb9d91bed07400659bc4ca35bcca79a7266b30dca9b749826L90-R92)
* Updated version to 0.0.14 and added a detailed changelog entry summarizing these bug fixes and improvements. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R15)