### PR TITLE
Fix/sorting feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.26](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.25...v0.0.26) (2025-10-27)
+
+### Features
+
+- Dropdown for convolved sound ([ad00857](https://github.com/ajatdarojat45/frontend-v2/commit/ad00857ac86dbbe531f5a6671df6ef1f3536e013))
+- Make side-panel resizable ([5c592c5](https://github.com/ajatdarojat45/frontend-v2/commit/5c592c5c0ec3c88787e221057b200ffa83f5b0ac))
+
+### Bug Fixes
+
+- Auralization does not update when re-running simulations ([d15330e](https://github.com/ajatdarojat45/frontend-v2/commit/d15330e082b0eb94653e2dd3260a5561fd12536a))
+- Content cannot be scroll after implement resizable pane ([631ad3a](https://github.com/ajatdarojat45/frontend-v2/commit/631ad3a55b0ca5c686e0e5b3b9e590a7ea448612))
+- Refresh needed after addition or deletion model ([4ce0f4e](https://github.com/ajatdarojat45/frontend-v2/commit/4ce0f4e063f47df7cc16f4f3874b95b6b0d8ce2d))
+- Units missing in the results panel ([f37581e](https://github.com/ajatdarojat45/frontend-v2/commit/f37581ece7529661a1bea2aa5176cc79bd933dbe))
+- Viewport width when side-panel is resizing ([7d5c665](https://github.com/ajatdarojat45/frontend-v2/commit/7d5c6650a82457212fdc05e0743bb82f2fbc6795))
+
 ### [0.0.25](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.24...v0.0.25) (2025-10-26)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.27](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.26...v0.0.27) (2025-10-27)
+
+### Bug Fixes
+
+- Enhance project sorting by ID for ties in creation and modification dates ([2c2c927](https://github.com/ajatdarojat45/frontend-v2/commit/2c2c927d7a566daedd1a9b3db208e26c2101aace))
+- Improve model sorting by ID for ties in creation and modification dates ([d2f24ea](https://github.com/ajatdarojat45/frontend-v2/commit/d2f24ea81edb8a4805a053826f49855f31f2833e))
+
 ### [0.0.26](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.25...v0.0.26) (2025-10-27)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -35,13 +35,17 @@ export function HomePage() {
       case "DESC":
         return sortedProjects.sort((a, b) => b.name.localeCompare(a.name));
       case "NEWEST_FIRST":
-        return sortedProjects.sort(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
+        return sortedProjects.sort((a, b) => {
+          const timeDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          // If timestamps are the same, sort by ID (higher ID = newer)
+          return timeDiff !== 0 ? timeDiff : b.id - a.id;
+        });
       case "LAST_MODIFIED":
-        return sortedProjects.sort(
-          (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-        );
+        return sortedProjects.sort((a, b) => {
+          const timeDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+          // If timestamps are the same, sort by ID (higher ID = newer)
+          return timeDiff !== 0 ? timeDiff : b.id - a.id;
+        });
       default:
         return sortedProjects.sort((a, b) => a.name.localeCompare(b.name));
     }

--- a/src/pages/ProjectDetailPage.tsx
+++ b/src/pages/ProjectDetailPage.tsx
@@ -33,13 +33,17 @@ export function ProjectDetailPage() {
       case "DESC":
         return sortedModels.sort((a, b) => b.name.localeCompare(a.name));
       case "NEWEST_FIRST":
-        return sortedModels.sort(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-        );
+        return sortedModels.sort((a, b) => {
+          const timeDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          // If timestamps are the same, sort by ID (higher ID = newer)
+          return timeDiff !== 0 ? timeDiff : b.id - a.id;
+        });
       case "LAST_MODIFIED":
-        return sortedModels.sort(
-          (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-        );
+        return sortedModels.sort((a, b) => {
+          const timeDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+          // If timestamps are the same, sort by ID (higher ID = newer)
+          return timeDiff !== 0 ? timeDiff : b.id - a.id;
+        });
       default:
         return sortedModels.sort((a, b) => a.name.localeCompare(b.name));
     }


### PR DESCRIPTION
This pull request improves the sorting logic for both projects and models to ensure consistent ordering when creation or modification timestamps are identical. Now, if two items have the same timestamp, they are further sorted by their IDs, with higher IDs considered newer. The version is also bumped to 0.0.27, and the changelog is updated to reflect these and previous recent changes.

Sorting improvements:

* Updated project sorting in `HomePage.tsx` so that if two projects have the same creation or modification date, they are sorted by ID (higher ID is newer).
* Updated model sorting in `ProjectDetailPage.tsx` to use the same tie-breaker by ID when dates are equal.

Versioning and documentation:

* Bumped the app version to 0.0.27 in `package.json`.
* Updated `CHANGELOG.md` to document the new version, including the sorting improvements and previous recent changes.