### PR TITLE
Fix/results bugs

### DIFF
--- a/src/components/features/results/TrapezoidOutlineTab.tsx
+++ b/src/components/features/results/TrapezoidOutlineTab.tsx
@@ -12,10 +12,14 @@ export function TrapezoidOutlineTab({ value, children, ...restProps }: Trapezoid
       {...restProps}
       value={value}
       className={cn(
-        "relative text-sm font-medium w-full h-8 flex items-center justify-center cursor-pointer transition-colors",
+        "relative text-sm font-medium h-[200px] w-8 flex items-center justify-center cursor-pointer transition-colors",
         "text-black/50 hover:text-black",
         "data-[state=active]:text-black",
       )}
+      style={{
+        writingMode: "vertical-rl",
+        textOrientation: "mixed",
+      }}
     >
       <svg
         className="absolute inset-0 w-full h-full pointer-events-none"
@@ -24,7 +28,7 @@ export function TrapezoidOutlineTab({ value, children, ...restProps }: Trapezoid
       >
         <polygon
           data-state={restProps["data-state"]}
-          points="0,0 100,0 100,1 85,99.5 15,99.5 0,1"
+          points="0,0 1,0 100,15 100,85 1,100 0,100"
           fill="none"
           stroke="currentColor"
           strokeWidth="1"

--- a/src/components/features/results/TrapezoidOutlineTab.tsx
+++ b/src/components/features/results/TrapezoidOutlineTab.tsx
@@ -12,7 +12,7 @@ export function TrapezoidOutlineTab({ value, children, ...restProps }: Trapezoid
       {...restProps}
       value={value}
       className={cn(
-        "relative text-sm font-medium h-[200px] w-8 flex items-center justify-center cursor-pointer transition-colors",
+        "relative text-sm font-medium h-50 w-8 flex items-center justify-center cursor-pointer transition-colors",
         "text-black/50 hover:text-black",
         "data-[state=active]:text-black",
       )}

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -226,10 +226,10 @@ export function SurfacesTab() {
           <table className="w-full table-fixed">
             <thead>
               <tr>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/3">
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-36">
                   Surface
                 </th>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-1/3">
+                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
                   Material
                 </th>
               </tr>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -55,8 +55,9 @@ export function ResultPage() {
       sidebar={<CompareResult modelId={+modelId} />}
     >
       <EditorNav active="results" modelId={+modelId} simulationId={+simulationId} />
+
       <Tabs defaultValue="parameters" className="mt-8">
-        <TabsList className="mx-auto bg-transparent w-80 p-0 h-8 absolute right-0 top-16 border-0">
+        <TabsList className="bg-transparent absolute bottom-0 h-100 w-8 p-0 flex-col rounded-r-xl roundedn-l-none z-50">
           <TabsTrigger value="parameters" asChild>
             <TrapezoidOutlineTab value="parameters">Parameters</TrapezoidOutlineTab>
           </TabsTrigger>
@@ -64,10 +65,10 @@ export function ResultPage() {
             <TrapezoidOutlineTab value="auralizations">Auralizations</TrapezoidOutlineTab>
           </TabsTrigger>
         </TabsList>
-        <TabsContent value="parameters">
+        <TabsContent value="parameters" className="pl-4">
           <ResultParameters simulationId={+simulationId} />
         </TabsContent>
-        <TabsContent value="auralizations">
+        <TabsContent value="auralizations" className="pl-4">
           <ResultAuralizations simulationId={+simulationId} />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
This pull request updates the layout and visual style of the results and simulation settings tabs to improve clarity and usability. The main changes focus on making the results tabs vertical with a distinctive trapezoidal outline, and adjusting table column widths for better alignment.

**Results Tabs Redesign:**

- Changed the results tabs (`TabsList` in `ResultPage.tsx`) from a horizontal to a vertical orientation, positioning them on the left with increased height and width, and updated styling for a more prominent appearance. (`[src/pages/ResultPage.tsxR58-R71](diffhunk://#diff-73426a0e72301264c7210082d12075fc4bb8d0d0cb2e1c89cb314ebf5efa5ab7R58-R71)`)
- Updated the `TrapezoidOutlineTab` component to use vertical writing mode, adjusted dimensions (height and width), and modified the SVG polygon points to create a vertical trapezoidal outline. (`[[1]](diffhunk://#diff-5a850d0f6aded9db7e93ea60c482c91e78256ac73bc0780f20c9d75d6cb4bda9L15-R22)`, `[[2]](diffhunk://#diff-5a850d0f6aded9db7e93ea60c482c91e78256ac73bc0780f20c9d75d6cb4bda9L27-R31)`)

**Simulation Settings Table Adjustment:**

- Modified the column width of the "Surface" header in the surfaces table to a fixed width (`w-36`) for more consistent alignment, and removed the fixed width from the "Material" column. (`[src/components/features/simulationSettings/SurfacesTab.tsxL229-R232](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56L229-R232)`)