### PR TITLE
Fix/assign all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.33](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.32...v0.0.33) (2025-10-28)
+
+### Features
+
+- add mixed material detection for surfaces and update UI accordingly ([b7b6917](https://github.com/ajatdarojat45/frontend-v2/commit/b7b6917a13636c5db1c8d199d793b6a7658cc2da))
+
 ### [0.0.32](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.31...v0.0.32) (2025-10-27)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.32",
+  "version": "0.0.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -163,6 +163,22 @@ export function SurfacesTab() {
     return material?.name || "Unknown Material";
   };
 
+  const isMaterialsMixed = () => {
+    if (surfaces.length === 0) return false;
+
+    // Get material assignment for each surface (undefined for None)
+    const allMaterials = surfaces.map((surface) => {
+      const surfaceKey = surface.id;
+      return materialAssignments[surfaceKey]; // undefined if not assigned (None)
+    });
+
+    // Create set of unique materials (including undefined for None)
+    const uniqueMaterials = new Set(allMaterials);
+
+    // Mixed if there are more than 1 unique material states
+    return uniqueMaterials.size > 1;
+  };
+
   const getDisplayName = (surface: SurfaceInfo, index: number) => {
     if (surface.name && surface.name !== `Surface ${surface.meshId}`) {
       return surface.name;
@@ -172,6 +188,11 @@ export function SurfacesTab() {
 
   const getAssignAllValue = () => {
     if (surfaces.length === 0) return "default";
+
+    // Check if materials are mixed first
+    if (isMaterialsMixed()) {
+      return "mixed";
+    }
 
     const assignedMaterials = surfaces.map((surface) => {
       const surfaceKey = surface.id;
@@ -248,7 +269,7 @@ export function SurfacesTab() {
                     >
                       <ChevronRight size={16} />
                     </span>
-                    Assign All
+                    Assign all
                   </button>
                 </td>
                 <td className="px-3 py-2">
@@ -257,11 +278,18 @@ export function SurfacesTab() {
                       size="sm"
                       className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
                     >
-                      <SelectValue placeholder="Select material for all surfaces" />
+                      {isMaterialsMixed() ? (
+                        <div className="flex items-center text-white">Mixed</div>
+                      ) : (
+                        <SelectValue placeholder="Select material for all surfaces" />
+                      )}
                     </SelectTrigger>
                     <SelectContent className="bg-choras-dark border-choras-gray">
                       <SelectItem value="default" className="text-white">
-                        All Assignment
+                        None
+                      </SelectItem>
+                      <SelectItem value="mixed" className="text-gray-400" disabled hidden>
+                        Mixed
                       </SelectItem>
                       {materialsLoading ? (
                         <SelectItem value="loading" disabled className="text-gray-400">
@@ -343,7 +371,7 @@ export function SurfacesTab() {
                           </SelectTrigger>
                           <SelectContent className="bg-choras-dark border-choras-gray">
                             <SelectItem value="default" className="text-white">
-                              Default
+                              None
                             </SelectItem>
                             {materialsLoading ? (
                               <SelectItem value="loading" disabled className="text-gray-400">


### PR DESCRIPTION
This pull request introduces a new feature for detecting and displaying mixed material assignments for surfaces in the simulation settings UI. The main changes include logic to determine when surfaces have different materials assigned and updates to the UI to reflect this state, along with minor text adjustments for clarity.

**Mixed Material Detection and UI Updates:**

* Added an `isMaterialsMixed` function in `SurfacesTab.tsx` to determine if multiple materials (including "None") are assigned across surfaces.
* Updated the "Assign all" select dropdown to display "Mixed" when surfaces have different materials assigned, and adjusted the placeholder and options for clarity ("None" instead of "Default"/"All Assignment"). [[1]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R192-R196) [[2]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R281-R292) [[3]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56L346-R374)
* Changed button label from "Assign All" to "Assign all" for consistency.

**Versioning and Documentation:**

* Incremented the app version to `0.0.33` in `package.json`.
* Added a changelog entry describing the new mixed material detection feature.