### PR TITLE
Feat/material library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.34](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.33...v0.0.34) (2025-10-28)
+
+### Features
+
+- enhance SurfacesTab with material library and create material dialog functionality ([5322d9e](https://github.com/ajatdarojat45/frontend-v2/commit/5322d9e613cea65dc8eae5d422948259b52ece2d))
+- refactor CreateMaterialDialog to accept props for open state management ([36e88e1](https://github.com/ajatdarojat45/frontend-v2/commit/36e88e1d5aad3df2433a118c535bf824ccb6ecc5))
+- refactor SurfaceMaterialList to accept props for dialog state management ([3c3c4f5](https://github.com/ajatdarojat45/frontend-v2/commit/3c3c4f5bc02e72bf7dbed93e8d5cd6a5b4c37983))
+
 ### [0.0.33](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.32...v0.0.33) (2025-10-28)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.33",
+  "version": "0.0.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/CreateMaterialDialog.tsx
+++ b/src/components/features/simulationSettings/CreateMaterialDialog.tsx
@@ -16,8 +16,15 @@ import { useState } from "react";
 import { useCreateMaterialMutation } from "@/store/materialsApi";
 import { toast } from "sonner";
 
-export function CreateMaterialDialog() {
-  const [open, setOpen] = useState(false);
+type IProps = {
+  openCreateMaterialDialog: boolean;
+  setOpenCreateMaterialDialog: (open: boolean) => void;
+};
+
+export function CreateMaterialDialog({
+  openCreateMaterialDialog,
+  setOpenCreateMaterialDialog,
+}: IProps) {
   const [createMaterial, { isLoading: isCreating }] = useCreateMaterialMutation();
 
   const [formData, setFormData] = useState({
@@ -53,7 +60,7 @@ export function CreateMaterialDialog() {
     try {
       await createMaterial(formData).unwrap();
       toast.success("Material created successfully!");
-      setOpen(false);
+      setOpenCreateMaterialDialog(false);
       setFormData({
         name: "",
         description: "",
@@ -67,7 +74,7 @@ export function CreateMaterialDialog() {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={openCreateMaterialDialog} onOpenChange={setOpenCreateMaterialDialog}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="flex items-center gap-2">
           <Plus size={16} />

--- a/src/components/features/simulationSettings/SurfaceMaterialList.tsx
+++ b/src/components/features/simulationSettings/SurfaceMaterialList.tsx
@@ -6,7 +6,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { EllipsisVertical, Search } from "lucide-react";
@@ -15,8 +14,19 @@ import { useGetMaterialsQuery } from "@/store/materialsApi";
 import type { Material } from "@/types/material";
 import { CreateMaterialDialog } from "./CreateMaterialDialog";
 
-export function SurfaceMaterialList() {
-  const [open, setOpen] = useState(false);
+type IProps = {
+  openMaterialLibrary: boolean;
+  setOpenMaterialLibrary: (open: boolean) => void;
+  openCreateMaterialDialog: boolean;
+  setOpenCreateMaterialDialog: (open: boolean) => void;
+};
+
+export function SurfaceMaterialList({
+  openMaterialLibrary,
+  setOpenMaterialLibrary,
+  openCreateMaterialDialog,
+  setOpenCreateMaterialDialog,
+}: IProps) {
   const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const { data: materials = [], isLoading, error } = useGetMaterialsQuery();
@@ -26,18 +36,19 @@ export function SurfaceMaterialList() {
   );
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" className="rounded-full hover:bg-gray-600 hover:text-white">
-          <EllipsisVertical size={20} className="text-white" />
-        </Button>
-      </DialogTrigger>
+    <Dialog open={openMaterialLibrary} onOpenChange={setOpenMaterialLibrary}>
+      <Button variant="ghost" className="rounded-full hover:bg-gray-600 hover:text-white">
+        <EllipsisVertical size={20} className="text-white" />
+      </Button>
       <DialogContent className="sm:max-w-3xl max-w-lg border border-transparent bg-gradient-to-r from-choras-primary from-50% to-choras-secondary bg-clip-border p-0.5">
         <div className="bg-white p-6 rounded-lg space-y-6">
           <DialogHeader>
             <div className="flex justify-between items-center mt-4">
               <DialogTitle className="text-xl text-choras-primary">Materials</DialogTitle>
-              <CreateMaterialDialog />
+              <CreateMaterialDialog
+                openCreateMaterialDialog={openCreateMaterialDialog}
+                setOpenCreateMaterialDialog={setOpenCreateMaterialDialog}
+              />
             </div>
             <DialogDescription>List of Material Available</DialogDescription>
           </DialogHeader>

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -21,9 +21,10 @@ import {
 } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { SurfaceInfo } from "@/types/material";
-import { ChevronRight, Eye, EyeOff } from "lucide-react";
+import { ChevronRight, Eye, EyeOff, Plus } from "lucide-react";
 import { SurfaceMaterialList } from "./SurfaceMaterialList";
 import { AbsorptionCoefficientChart } from "./AbsorptionCoefficientChart";
+import { Button } from "@/components/ui/button";
 
 export function SurfacesTab() {
   const dispatch = useDispatch();
@@ -48,6 +49,8 @@ export function SurfacesTab() {
     },
   );
   const [updateSimulation] = useUpdateSimulationMutation();
+  const [openMaterialLibrary, setOpenMaterialLibrary] = useState(false);
+  const [openCreateMaterialDialog, setOpenCreateMaterialDialog] = useState(false);
 
   useEffect(() => {
     if (simulation?.layerIdByMaterialId) {
@@ -229,204 +232,240 @@ export function SurfacesTab() {
     });
   }, [surfaces, hiddenSurfaces]);
 
+  const handleOpenCreateMaterialDialog = () => {
+    setOpenMaterialLibrary(true);
+    setTimeout(() => {
+      setOpenCreateMaterialDialog(true);
+    }, 500);
+  };
+
   return (
-    <div className="text-white">
-      <div className="mb-4 flex justify-between items-center">
-        <h4 className="text-xl text-choras-primary">Surfaces</h4>
-        <SurfaceMaterialList />
+    <div className="text-white h-full flex flex-col justify-between">
+      <div>
+        <div className="mb-4 flex justify-between items-center">
+          <h4 className="text-xl text-choras-primary">Surfaces</h4>
+          <SurfaceMaterialList
+            openMaterialLibrary={openMaterialLibrary}
+            setOpenMaterialLibrary={setOpenMaterialLibrary}
+            openCreateMaterialDialog={openCreateMaterialDialog}
+            setOpenCreateMaterialDialog={setOpenCreateMaterialDialog}
+          />
+        </div>
+
+        {surfaces.length === 0 ? (
+          <div className="text-gray-400 text-sm italic">No model loaded or no surfaces found</div>
+        ) : (
+          <div
+            className={`overflow-hidden transition-all duration-500 ${
+              highlightedElement === "material-assignment"
+                ? "ring-2 ring-yellow-400 shadow-lg animate-pulse bg-yellow-500/10 rounded-lg p-2"
+                : ""
+            }`}
+          >
+            <table className="w-full table-fixed">
+              <thead>
+                <tr>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-36">
+                    Surface
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
+                    Material
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-choras-gray">
+                  <td className="px-3 py-2 text-sm">
+                    <button
+                      onClick={() => setShowIndividualAssignments(!showIndividualAssignments)}
+                      className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors"
+                    >
+                      <span
+                        className={`transform transition-transform ${showIndividualAssignments ? "rotate-90" : "rotate-0"}`}
+                      >
+                        <ChevronRight size={16} />
+                      </span>
+                      Assign all
+                    </button>
+                  </td>
+                  <td className="px-3 py-2">
+                    <Select value={getAssignAllValue()} onValueChange={handleAssignAllMaterials}>
+                      <SelectTrigger
+                        size="sm"
+                        className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                      >
+                        {isMaterialsMixed() ? (
+                          <div className="flex items-center text-white">Mixed</div>
+                        ) : (
+                          <SelectValue placeholder="Select material for all surfaces" />
+                        )}
+                      </SelectTrigger>
+                      <SelectContent className="bg-choras-dark border-choras-gray">
+                        <SelectItem value="default" className="text-white">
+                          None
+                        </SelectItem>
+                        <SelectItem value="mixed" className="text-gray-400" disabled hidden>
+                          Mixed
+                        </SelectItem>
+                        {materialsLoading ? (
+                          <SelectItem value="loading" disabled className="text-gray-400">
+                            Loading materials...
+                          </SelectItem>
+                        ) : materialsError ? (
+                          <SelectItem value="error" disabled className="text-red-400">
+                            Error loading materials
+                          </SelectItem>
+                        ) : (
+                          <TooltipProvider>
+                            {materials.map((material) => (
+                              <Tooltip key={material.id} delayDuration={300}>
+                                <TooltipTrigger asChild>
+                                  <SelectItem value={material.id.toString()} className="text-white">
+                                    <span className="truncate block" title={material.name}>
+                                      {material.name}
+                                    </span>
+                                  </SelectItem>
+                                </TooltipTrigger>
+                                <TooltipContent
+                                  side="right"
+                                  className="p-3 bg-choras-dark border-choras-primary"
+                                >
+                                  <div className="text-sm mb-2 font-medium text-white">
+                                    {material.name}
+                                  </div>
+                                  <AbsorptionCoefficientChart
+                                    coefficients={material.absorptionCoefficients}
+                                    size="md"
+                                  />
+                                </TooltipContent>
+                              </Tooltip>
+                            ))}
+                          </TooltipProvider>
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </td>
+                </tr>
+
+                {showIndividualAssignments &&
+                  surfaces.map((surface, index) => {
+                    const surfaceKey = surface.id;
+                    const assignedMaterialId = materialAssignments[surfaceKey];
+
+                    return (
+                      <tr
+                        key={surface.id}
+                        className="hover:bg-choras-dark/90 border-t border-gray-700"
+                      >
+                        <td className="px-3 py-2 text-sm w-1/3">
+                          <div className="flex items-center gap-2">
+                            <div
+                              onClick={() => toggleSurfaceVisibility(surfaceKey)}
+                              className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
+                            >
+                              {hiddenSurfaces.has(surfaceKey) ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </div>
+                            <div className="font-medium truncate">
+                              {getDisplayName(surface, index)}
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-3 py-2 w-1/3">
+                          <Select
+                            value={assignedMaterialId?.toString() || "default"}
+                            onValueChange={(value) => handleMaterialAssignment(surfaceKey, value)}
+                          >
+                            <SelectTrigger
+                              size="sm"
+                              className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
+                            >
+                              <SelectValue placeholder={getMaterialName(assignedMaterialId)} />
+                            </SelectTrigger>
+                            <SelectContent className="bg-choras-dark border-choras-gray">
+                              <SelectItem value="default" className="text-white">
+                                None
+                              </SelectItem>
+                              {materialsLoading ? (
+                                <SelectItem value="loading" disabled className="text-gray-400">
+                                  Loading materials...
+                                </SelectItem>
+                              ) : materialsError ? (
+                                <SelectItem value="error" disabled className="text-red-400">
+                                  Error loading materials
+                                </SelectItem>
+                              ) : (
+                                <TooltipProvider>
+                                  {materials.map((material) => (
+                                    <Tooltip key={material.id} delayDuration={300}>
+                                      <TooltipTrigger asChild>
+                                        <SelectItem
+                                          value={material.id.toString()}
+                                          className="text-white"
+                                        >
+                                          <span className="truncate block" title={material.name}>
+                                            {material.name}
+                                          </span>
+                                        </SelectItem>
+                                      </TooltipTrigger>
+                                      <TooltipContent
+                                        side="right"
+                                        className="p-3 bg-choras-dark border-choras-primary"
+                                      >
+                                        <div className="text-sm mb-2 font-medium text-white">
+                                          {material.name}
+                                        </div>
+                                        <AbsorptionCoefficientChart
+                                          coefficients={material.absorptionCoefficients}
+                                          size="md"
+                                        />
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  ))}
+                                </TooltipProvider>
+                              )}
+                            </SelectContent>
+                          </Select>
+                        </td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {surfaces.length > 0 && (
+          <div className="mt-4 pt-4 border-t border-choras-gray">
+            <div className="text-sm text-gray-400">Total: {surfaces.length} surfaces found</div>
+          </div>
+        )}
       </div>
 
-      {surfaces.length === 0 ? (
-        <div className="text-gray-400 text-sm italic">No model loaded or no surfaces found</div>
-      ) : (
-        <div
-          className={`overflow-hidden transition-all duration-500 ${
-            highlightedElement === "material-assignment"
-              ? "ring-2 ring-yellow-400 shadow-lg animate-pulse bg-yellow-500/10 rounded-lg p-2"
-              : ""
-          }`}
-        >
-          <table className="w-full table-fixed">
-            <thead>
-              <tr>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider w-36">
-                  Surface
-                </th>
-                <th className="px-3 py-2 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">
-                  Material
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr className="border-b border-choras-gray">
-                <td className="px-3 py-2 text-sm">
-                  <button
-                    onClick={() => setShowIndividualAssignments(!showIndividualAssignments)}
-                    className="flex items-center gap-2 font-medium text-white hover:text-gray-300 transition-colors"
-                  >
-                    <span
-                      className={`transform transition-transform ${showIndividualAssignments ? "rotate-90" : "rotate-0"}`}
-                    >
-                      <ChevronRight size={16} />
-                    </span>
-                    Assign all
-                  </button>
-                </td>
-                <td className="px-3 py-2">
-                  <Select value={getAssignAllValue()} onValueChange={handleAssignAllMaterials}>
-                    <SelectTrigger
-                      size="sm"
-                      className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
-                    >
-                      {isMaterialsMixed() ? (
-                        <div className="flex items-center text-white">Mixed</div>
-                      ) : (
-                        <SelectValue placeholder="Select material for all surfaces" />
-                      )}
-                    </SelectTrigger>
-                    <SelectContent className="bg-choras-dark border-choras-gray">
-                      <SelectItem value="default" className="text-white">
-                        None
-                      </SelectItem>
-                      <SelectItem value="mixed" className="text-gray-400" disabled hidden>
-                        Mixed
-                      </SelectItem>
-                      {materialsLoading ? (
-                        <SelectItem value="loading" disabled className="text-gray-400">
-                          Loading materials...
-                        </SelectItem>
-                      ) : materialsError ? (
-                        <SelectItem value="error" disabled className="text-red-400">
-                          Error loading materials
-                        </SelectItem>
-                      ) : (
-                        <TooltipProvider>
-                          {materials.map((material) => (
-                            <Tooltip key={material.id} delayDuration={300}>
-                              <TooltipTrigger asChild>
-                                <SelectItem value={material.id.toString()} className="text-white">
-                                  <span className="truncate block" title={material.name}>
-                                    {material.name}
-                                  </span>
-                                </SelectItem>
-                              </TooltipTrigger>
-                              <TooltipContent
-                                side="right"
-                                className="p-3 bg-choras-dark border-choras-primary"
-                              >
-                                <div className="text-sm mb-2 font-medium text-white">
-                                  {material.name}
-                                </div>
-                                <AbsorptionCoefficientChart
-                                  coefficients={material.absorptionCoefficients}
-                                  size="md"
-                                />
-                              </TooltipContent>
-                            </Tooltip>
-                          ))}
-                        </TooltipProvider>
-                      )}
-                    </SelectContent>
-                  </Select>
-                </td>
-              </tr>
-
-              {showIndividualAssignments &&
-                surfaces.map((surface, index) => {
-                  const surfaceKey = surface.id;
-                  const assignedMaterialId = materialAssignments[surfaceKey];
-
-                  return (
-                    <tr
-                      key={surface.id}
-                      className="hover:bg-choras-dark/90 border-t border-gray-700"
-                    >
-                      <td className="px-3 py-2 text-sm w-1/3">
-                        <div className="flex items-center gap-2">
-                          <div
-                            onClick={() => toggleSurfaceVisibility(surfaceKey)}
-                            className="cursor-pointer text-white hover:text-gray-300 transition-colors flex-shrink-0"
-                          >
-                            {hiddenSurfaces.has(surfaceKey) ? (
-                              <EyeOff className="h-4 w-4" />
-                            ) : (
-                              <Eye className="h-4 w-4" />
-                            )}
-                          </div>
-                          <div className="font-medium truncate">
-                            {getDisplayName(surface, index)}
-                          </div>
-                        </div>
-                      </td>
-                      <td className="px-3 py-2 w-1/3">
-                        <Select
-                          value={assignedMaterialId?.toString() || "default"}
-                          onValueChange={(value) => handleMaterialAssignment(surfaceKey, value)}
-                        >
-                          <SelectTrigger
-                            size="sm"
-                            className="w-full bg-choras-dark border-choras-gray text-white [&>span]:truncate [&>span]:block [&>span]:max-w-full [&>svg]:text-choras-gray"
-                          >
-                            <SelectValue placeholder={getMaterialName(assignedMaterialId)} />
-                          </SelectTrigger>
-                          <SelectContent className="bg-choras-dark border-choras-gray">
-                            <SelectItem value="default" className="text-white">
-                              None
-                            </SelectItem>
-                            {materialsLoading ? (
-                              <SelectItem value="loading" disabled className="text-gray-400">
-                                Loading materials...
-                              </SelectItem>
-                            ) : materialsError ? (
-                              <SelectItem value="error" disabled className="text-red-400">
-                                Error loading materials
-                              </SelectItem>
-                            ) : (
-                              <TooltipProvider>
-                                {materials.map((material) => (
-                                  <Tooltip key={material.id} delayDuration={300}>
-                                    <TooltipTrigger asChild>
-                                      <SelectItem
-                                        value={material.id.toString()}
-                                        className="text-white"
-                                      >
-                                        <span className="truncate block" title={material.name}>
-                                          {material.name}
-                                        </span>
-                                      </SelectItem>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="right"
-                                      className="p-3 bg-choras-dark border-choras-primary"
-                                    >
-                                      <div className="text-sm mb-2 font-medium text-white">
-                                        {material.name}
-                                      </div>
-                                      <AbsorptionCoefficientChart
-                                        coefficients={material.absorptionCoefficients}
-                                        size="md"
-                                      />
-                                    </TooltipContent>
-                                  </Tooltip>
-                                ))}
-                              </TooltipProvider>
-                            )}
-                          </SelectContent>
-                        </Select>
-                      </td>
-                    </tr>
-                  );
-                })}
-            </tbody>
-          </table>
+      <div>
+        <div className="grid grid-cols-2 gap-4 w-full items-center mb-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex items-center text-xs"
+            onClick={() => setOpenMaterialLibrary(true)}
+          >
+            Open material library
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex items-center text-xs"
+            onClick={handleOpenCreateMaterialDialog}
+          >
+            <Plus size={14} />
+            <span className="-ml-1">Create new material</span>
+          </Button>
         </div>
-      )}
-
-      {surfaces.length > 0 && (
-        <div className="mt-4 pt-4 border-t border-choras-gray">
-          <div className="text-sm text-gray-400">Total: {surfaces.length} surfaces found</div>
-        </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request enhances the material management functionality in the Surfaces section by introducing a material library and improving the creation of new materials. The main changes revolve around better dialog state management and a more user-friendly interface for accessing and creating materials.

**Material library and dialog enhancements:**

* Added a material library dialog to `SurfacesTab`, allowing users to view and manage available materials. The dialog's open state is now controlled via props for better state management. (F7ee27beL49R49, F36b4784L14R14, F36b4784L36R36)
* Refactored `CreateMaterialDialog` to accept props for its open state, enabling parent components to control when the dialog is shown. This improves consistency and makes it easier to trigger the dialog from different places. [[1]](diffhunk://#diff-f038c170e71a2344e62dd9e3718ba6282207455b5fd1d4dad5e9f63dda89dfccL19-R27) [[2]](diffhunk://#diff-f038c170e71a2344e62dd9e3718ba6282207455b5fd1d4dad5e9f63dda89dfccL70-R77)
* Updated `SurfaceMaterialList` to accept and pass down dialog state props, allowing coordinated control over both the material library and material creation dialogs. (F36b4784L14R14, F36b4784L36R36)
* Added buttons to `SurfacesTab` for opening the material library and directly triggering the create material dialog, enhancing accessibility and user workflow. ([src/components/features/simulationSettings/SurfacesTab.tsxR447-R469](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R447-R469), F7ee27beL232R232)

**Documentation and versioning:**

* Updated `CHANGELOG.md` and bumped the version to `0.0.34` in `package.json` to reflect these new features and improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4)