### PR TITLE
Feat/material library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.35](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.34...v0.0.35) (2025-10-28)
+
+### Features
+
+- add functionality to open material library from material assignment options ([36759a7](https://github.com/ajatdarojat45/frontend-v2/commit/36759a719c277aac0c08403ffae30a4e11bf66b0))
+
 ### [0.0.34](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.33...v0.0.34) (2025-10-28)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.34",
+  "version": "0.0.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/SurfaceMaterialList.tsx
+++ b/src/components/features/simulationSettings/SurfaceMaterialList.tsx
@@ -1,4 +1,3 @@
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -8,7 +7,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { EllipsisVertical, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { useState } from "react";
 import { useGetMaterialsQuery } from "@/store/materialsApi";
 import type { Material } from "@/types/material";
@@ -37,9 +36,9 @@ export function SurfaceMaterialList({
 
   return (
     <Dialog open={openMaterialLibrary} onOpenChange={setOpenMaterialLibrary}>
-      <Button variant="ghost" className="rounded-full hover:bg-gray-600 hover:text-white">
+      {/* <Button variant="ghost" className="rounded-full hover:bg-gray-600 hover:text-white">
         <EllipsisVertical size={20} className="text-white" />
-      </Button>
+      </Button> */}
       <DialogContent className="sm:max-w-3xl max-w-lg border border-transparent bg-gradient-to-r from-choras-primary from-50% to-choras-secondary bg-clip-border p-0.5">
         <div className="bg-white p-6 rounded-lg space-y-6">
           <DialogHeader>

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -127,6 +127,11 @@ export function SurfacesTab() {
   );
 
   const handleMaterialAssignment = async (surfaceKey: string, materialId: string) => {
+    if (materialId === "open-library") {
+      setOpenMaterialLibrary(true);
+      return;
+    }
+
     let updatedAssignments: Record<string, number>;
 
     if (materialId === "default") {
@@ -142,6 +147,11 @@ export function SurfacesTab() {
   };
 
   const handleAssignAllMaterials = async (materialId: string) => {
+    if (materialId === "open-library") {
+      setOpenMaterialLibrary(true);
+      return;
+    }
+
     let updatedAssignments: Record<string, number>;
 
     if (materialId === "default") {
@@ -242,7 +252,7 @@ export function SurfacesTab() {
   return (
     <div className="text-white h-full flex flex-col justify-between">
       <div>
-        <div className="mb-4 flex justify-between items-center">
+        <div className="mb-4 flex justify-between items-center mt-2">
           <h4 className="text-xl text-choras-primary">Surfaces</h4>
           <SurfaceMaterialList
             openMaterialLibrary={openMaterialLibrary}
@@ -340,6 +350,12 @@ export function SurfacesTab() {
                                 </TooltipContent>
                               </Tooltip>
                             ))}
+                            <SelectItem
+                              value="open-library"
+                              className="text-choras-primary italic border-t border-choras-gray mt-1 pt-2"
+                            >
+                              Open material library...
+                            </SelectItem>
                           </TooltipProvider>
                         )}
                       </SelectContent>
@@ -425,6 +441,12 @@ export function SurfacesTab() {
                                       </TooltipContent>
                                     </Tooltip>
                                   ))}
+                                  <SelectItem
+                                    value="open-library"
+                                    className="text-choras-primary italic border-t border-choras-gray mt-1 pt-2"
+                                  >
+                                    Open material library...
+                                  </SelectItem>
                                 </TooltipProvider>
                               )}
                             </SelectContent>
@@ -462,7 +484,7 @@ export function SurfacesTab() {
             onClick={handleOpenCreateMaterialDialog}
           >
             <Plus size={14} />
-            <span className="-ml-1">Create new material</span>
+            <span>Create material</span>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
This pull request adds a new feature that allows users to open the material library directly from the material assignment options in the surfaces simulation settings. This enhancement improves the user experience by making it easier to access and select materials. Additionally, there are minor UI text and spacing adjustments.

**Material Library Access Improvements:**
* Added an "Open material library..." option to the material assignment dropdowns, enabling users to open the material library dialog directly from assignment menus. Selecting this option triggers the material library dialog instead of assigning a material. [[1]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R353-R358) [[2]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R444-R449) [[3]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R130-R134) [[4]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56R150-R154)

**UI and Usability Adjustments:**
* Adjusted spacing and margin for the surfaces section header for better visual alignment.
* Updated button text from "Create new material" to "Create material" for conciseness.
* Removed unused imports and commented out an unused button in `SurfaceMaterialList.tsx` for code cleanliness. [[1]](diffhunk://#diff-1b24eb2f59ca6acadfaa4058d3dcd74577368fdd7683f715997364c78daa1055L1) [[2]](diffhunk://#diff-1b24eb2f59ca6acadfaa4058d3dcd74577368fdd7683f715997364c78daa1055L11-R10) [[3]](diffhunk://#diff-1b24eb2f59ca6acadfaa4058d3dcd74577368fdd7683f715997364c78daa1055L40-R41)

**Versioning and Documentation:**
* Bumped the app version to `0.0.35` and updated the `CHANGELOG.md` to document the new feature. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R10)