### PR TITLE
Feat/material library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.36](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.35...v0.0.36) (2025-10-28)
+
+### Bug Fixes
+
+- correct capitalization of "Create material" button text ([1cbf824](https://github.com/ajatdarojat45/frontend-v2/commit/1cbf824c9a39b1f77912de07ccaa670a7d569035))
+- improve UI consistency by updating "Open material library" text and adding separators ([8440c57](https://github.com/ajatdarojat45/frontend-v2/commit/8440c57e3be46055afe59ddde9f3b071c6663114))
+- update dialog titles for clarity in SurfaceMaterialList ([4b2666c](https://github.com/ajatdarojat45/frontend-v2/commit/4b2666c451063369ee9a6dcc0a6394f7ed6b8983))
+
 ### [0.0.35](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.34...v0.0.35) (2025-10-28)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.35",
+  "version": "0.0.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/simulationSettings/CreateMaterialDialog.tsx
+++ b/src/components/features/simulationSettings/CreateMaterialDialog.tsx
@@ -78,7 +78,7 @@ export function CreateMaterialDialog({
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="flex items-center gap-2">
           <Plus size={16} />
-          Create Material
+          Create material
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-2xl">

--- a/src/components/features/simulationSettings/SurfaceMaterialList.tsx
+++ b/src/components/features/simulationSettings/SurfaceMaterialList.tsx
@@ -43,13 +43,13 @@ export function SurfaceMaterialList({
         <div className="bg-white p-6 rounded-lg space-y-6">
           <DialogHeader>
             <div className="flex justify-between items-center mt-4">
-              <DialogTitle className="text-xl text-choras-primary">Materials</DialogTitle>
+              <DialogTitle className="text-xl text-choras-primary">Material library</DialogTitle>
               <CreateMaterialDialog
                 openCreateMaterialDialog={openCreateMaterialDialog}
                 setOpenCreateMaterialDialog={setOpenCreateMaterialDialog}
               />
             </div>
-            <DialogDescription>List of Material Available</DialogDescription>
+            <DialogDescription>Select a material to view its details</DialogDescription>
           </DialogHeader>
 
           <div className="relative">
@@ -122,7 +122,6 @@ export function SurfaceMaterialList({
             <div className="w-full">
               {selectedMaterial ? (
                 <div className="space-y-3">
-                  <h3 className="font-medium text-base">Material Details</h3>
                   <div className="bg-gray-50 p-4 rounded-lg w-full">
                     <h4 className="font-medium text-sm mb-3">{selectedMaterial.name}</h4>
                     <div className="w-full overflow-x-auto">

--- a/src/components/features/simulationSettings/SurfacesTab.tsx
+++ b/src/components/features/simulationSettings/SurfacesTab.tsx
@@ -350,11 +350,9 @@ export function SurfacesTab() {
                                 </TooltipContent>
                               </Tooltip>
                             ))}
-                            <SelectItem
-                              value="open-library"
-                              className="text-choras-primary italic border-t border-choras-gray mt-1 pt-2"
-                            >
-                              Open material library...
+                            <hr className="border-t border-gray-700 my-1" />
+                            <SelectItem value="open-library" className="text-choras-primary">
+                              Open material library
                             </SelectItem>
                           </TooltipProvider>
                         )}
@@ -441,11 +439,9 @@ export function SurfacesTab() {
                                       </TooltipContent>
                                     </Tooltip>
                                   ))}
-                                  <SelectItem
-                                    value="open-library"
-                                    className="text-choras-primary italic border-t border-choras-gray mt-1 pt-2"
-                                  >
-                                    Open material library...
+                                  <hr className="border-t border-gray-700 my-1" />
+                                  <SelectItem value="open-library" className="text-choras-primary">
+                                    Open material library
                                   </SelectItem>
                                 </TooltipProvider>
                               )}


### PR DESCRIPTION
This pull request focuses on improving the UI consistency and clarity for material-related dialogs and actions in the simulation settings. The changes mainly address button and dialog text, as well as the organization and appearance of the material library selection. These updates aim to provide a more consistent and user-friendly experience.

UI Consistency and Clarity Improvements:

* Changed the "Create Material" button text to "Create material" for correct capitalization in `CreateMaterialDialog.tsx`.
* Updated the dialog title from "Materials" to "Material library" and revised the description for clarity in `SurfaceMaterialList.tsx`.
* Removed the redundant "Material Details" heading in the material details section for a cleaner look in `SurfaceMaterialList.tsx`.
* Improved the appearance and wording of the "Open material library" option by removing italics, updating the text, and adding a separator in `SurfacesTab.tsx`. [[1]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56L353-R355) [[2]](diffhunk://#diff-050758027cd175ae8d78cf4ac462251747a50fdc4e02908f87be094f775c0c56L444-R444)

Documentation and Versioning:

* Updated `CHANGELOG.md` and bumped the version in `package.json` to 0.0.36 to reflect these UI bug fixes and improvements. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4)