### PR TITLE
Fix/only completed simulations for comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.41](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.40...v0.0.41) (2025-10-28)
+
+### Features
+
+- add clearCompareResults action to cleanup compare results on unmount ([b8b3a17](https://github.com/ajatdarojat45/frontend-v2/commit/b8b3a174b97c1000f43d0e819029b082bd4a94fc))
+- add clearCompareResults reducer to reset compare results ([4b25a86](https://github.com/ajatdarojat45/frontend-v2/commit/4b25a8683e6a7e2c338669713dbe1e83fe3bd327))
+
+### Bug Fixes
+
+- remove debug log and filter simulations by completed status ([31c47c3](https://github.com/ajatdarojat45/frontend-v2/commit/31c47c3c55bf3fa7cd77c623377595d710fce647))
+
 ### [0.0.40](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.39...v0.0.40) (2025-10-28)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.40",
+  "version": "0.0.41",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/results/CompareResult.tsx
+++ b/src/components/features/results/CompareResult.tsx
@@ -1,7 +1,11 @@
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { useDispatch, useSelector } from "react-redux";
-import { addCompareResult, initializeCompareResults } from "@/store/simulationSlice";
+import {
+  addCompareResult,
+  clearCompareResults,
+  initializeCompareResults,
+} from "@/store/simulationSlice";
 import type { RootState } from "@/store";
 import { useEffect } from "react";
 import { CompareResultItem } from "./CompareResultItem";
@@ -53,6 +57,12 @@ export function CompareResult({ modelId }: CompareResultProps) {
       );
     }
   }, [dispatch, compareResults.length, activeSimulation]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(clearCompareResults());
+    };
+  }, []);
 
   const handleAddResult = () => {
     const lastId = compareResults.length > 0 ? compareResults[compareResults.length - 1].id : "0";

--- a/src/components/features/results/CompareResultItem.tsx
+++ b/src/components/features/results/CompareResultItem.tsx
@@ -143,8 +143,6 @@ export function CompareResultItem({
   const sources = selectedSimulation?.sources || [];
   const receivers = selectedSimulation?.receivers || [];
 
-  console.log(model, "<<<");
-
   return (
     <div className="border-y border-stone-600 p-4 space-y-4 relative">
       {model && (
@@ -180,9 +178,11 @@ export function CompareResultItem({
               </SelectValue>
             </SelectTrigger>
             <SelectContent className="bg-choras-dark border-choras-gray">
-              {simulations?.map((simulation) => (
-                <CustomSelectItem key={simulation.id} simulation={simulation} />
-              ))}
+              {simulations
+                ?.filter((simulation) => simulation.status === "Completed")
+                .map((simulation) => (
+                  <CustomSelectItem key={simulation.id} simulation={simulation} />
+                ))}
             </SelectContent>
           </Select>
         </div>

--- a/src/store/simulationSlice.ts
+++ b/src/store/simulationSlice.ts
@@ -42,6 +42,9 @@ const simulationSlice = createSlice({
     initializeCompareResults: (state, action) => {
       state.compareResults = action.payload;
     },
+    clearCompareResults: (state) => {
+      state.compareResults = [];
+    },
   },
 });
 
@@ -51,6 +54,7 @@ export const {
   removeCompareResult,
   updateCompareResult,
   initializeCompareResults,
+  clearCompareResults,
 } = simulationSlice.actions;
 
 export const simulationReducer = simulationSlice.reducer;


### PR DESCRIPTION
This pull request introduces new features and a bug fix related to the management of compare results in the simulation feature. The main changes include adding actions and reducers to clear compare results when the relevant component unmounts, and filtering simulations to show only those with a "Completed" status. Additionally, debug logs have been removed for cleaner output.

**Compare Results Management:**

* Added a `clearCompareResults` action and reducer in `simulationSlice` to reset compare results, and invoked this action in a cleanup effect in the `CompareResult` component to ensure results are cleared on unmount. [[1]](diffhunk://#diff-61839b3e6dc108ea1d258cfba1fcd2d9d2fd27f5d7c6c844ca90e260879c7296R45-R47) [[2]](diffhunk://#diff-61839b3e6dc108ea1d258cfba1fcd2d9d2fd27f5d7c6c844ca90e260879c7296R57) [[3]](diffhunk://#diff-2213cb1d833074dfeb99b1ffd8fdf072e5e1f38ddf5efecdfb494a42137dc330L4-R8) [[4]](diffhunk://#diff-2213cb1d833074dfeb99b1ffd8fdf072e5e1f38ddf5efecdfb494a42137dc330R61-R66)

**Simulation Filtering and Cleanup:**

* Updated the `CompareResultItem` component to filter simulations, displaying only those with a `"Completed"` status, and removed an unnecessary debug log for improved clarity. [[1]](diffhunk://#diff-46f3832f8625b8eee35cbfaca91005402d107a826d315947b57ea2824800ef5bL146-L147) [[2]](diffhunk://#diff-46f3832f8625b8eee35cbfaca91005402d107a826d315947b57ea2824800ef5bL183-R183)

**Versioning and Documentation:**

* Bumped the app version to `0.0.41` and updated the `CHANGELOG.md` to reflect the new features and bug fixes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R15)