### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.52](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.51...v0.0.52) (2025-11-05)
+
+### Bug Fixes
+
+- import simulationApi and ensure cache invalidation on model deletion ([3e6959d](https://github.com/ajatdarojat45/frontend-v2/commit/3e6959d132402bc48b18b4d22806c3441140c0d3))
+- remove colons from labels in SimulationPicker for consistency ([a96ba40](https://github.com/ajatdarojat45/frontend-v2/commit/a96ba4025f24dea25bc67dbf3a73c6411aba861b))
+
 ### [0.0.51](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.50...v0.0.51) (2025-11-04)
 
 ### [0.0.50](https://github.com/ajatdarojat45/frontend-v2/compare/v0.0.49...v0.0.50) (2025-11-04)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/features/ModelCard.tsx
+++ b/src/components/features/ModelCard.tsx
@@ -28,7 +28,7 @@ export function ModelCard({ model }: ModelCardProps) {
   const [deleteModel] = useDeleteModelMutation();
   const { refetch } = useGetProjectQuery(model.projectId.toString());
 
-  const handleDeleteModel = async () => {
+  const handleDeleteModel: () => Promise<void> = async () => {
     try {
       await deleteModel(model.id).unwrap();
       dispatch(projectApi.util.invalidateTags([{ type: "Projects" }]));

--- a/src/components/features/ModelCard.tsx
+++ b/src/components/features/ModelCard.tsx
@@ -1,6 +1,6 @@
 import type { Model } from "@/types/model";
 import { EllipsisVerticalIcon } from "lucide-react";
-import { useGetSimulationsByModelIdQuery } from "@/store/simulationApi";
+import { simulationApi, useGetSimulationsByModelIdQuery } from "@/store/simulationApi";
 import { useDeleteModelMutation } from "@/store/modelApi";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { useDispatch } from "react-redux";
@@ -32,6 +32,7 @@ export function ModelCard({ model }: ModelCardProps) {
     try {
       await deleteModel(model.id).unwrap();
       dispatch(projectApi.util.invalidateTags([{ type: "Projects" }]));
+      dispatch(simulationApi.util.invalidateTags([{ type: "SimulationsByModel" }]));
       toast.success("Model deleted successfully");
     } catch {
       toast.error("Failed to delete model");

--- a/src/components/features/simulationSettings/MethodInfoDialog.tsx
+++ b/src/components/features/simulationSettings/MethodInfoDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { CircleHelp, FileText, GithubIcon } from "lucide-react";
+import { FileText, GithubIcon } from "lucide-react";
 
 type Method = {
   simulationType: string;
@@ -26,7 +26,22 @@ export function MethodInfoDialog({ method }: MethodInfoDialogProps) {
     <Dialog>
       <DialogTrigger asChild>
         <Button variant="ghost" size="icon" className="px-2 hover:bg-white/10 ml-2">
-          <CircleHelp className="size-6 text-white" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            className="lucide lucide-circle-question-mark-icon lucide-circle-question-mark text-white size-6"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+            <path d="M12 17h.01" />
+          </svg>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-2xl">

--- a/src/components/features/simulationSettings/SimulationPicker.tsx
+++ b/src/components/features/simulationSettings/SimulationPicker.tsx
@@ -177,7 +177,7 @@ export function SimulationPicker({ modelId, simulationId }: SimulationPickerProp
     <div className="space-y-4">
       <div className="grid grid-cols-3 gap-3 w-full items-center">
         <label htmlFor="simulation" className="font-medium text-white">
-          Simulation:
+          Simulation
         </label>
         <div className="col-span-2 flex">
           <Select onValueChange={handleSimulationChange} value={simulationId?.toString()}>
@@ -266,7 +266,7 @@ export function SimulationPicker({ modelId, simulationId }: SimulationPickerProp
           </DropdownMenu>
         </div>
         <label htmlFor="method" className="font-medium text-white">
-          Method:
+          Method
         </label>
         <div className="col-span-2 flex">
           <Select value={selectedMethodType} onValueChange={handleMethodChange}>

--- a/src/components/features/viewport/EditorNav.tsx
+++ b/src/components/features/viewport/EditorNav.tsx
@@ -1,7 +1,6 @@
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSimulationRunner } from "@/hooks/useSimulationRunner";
 import { useGetSimulationResultQuery } from "@/store/simulationApi";
-import { useEffect, useState } from "react";
 import { Link } from "react-router";
 
 type EditorNavProps = {
@@ -12,18 +11,7 @@ type EditorNavProps = {
 
 export function EditorNav({ active, modelId, simulationId }: EditorNavProps) {
   const { data: result } = useGetSimulationResultQuery(simulationId);
-  const { isRunning, progress } = useSimulationRunner();
-  const [isCompleted, setIsCompleted] = useState(false);
-
-  useEffect(() => {
-    if (progress >= 90) {
-      setIsCompleted(() => true);
-      const timer = setTimeout(() => {
-        setIsCompleted(false);
-      }, 6000);
-      return () => clearTimeout(timer);
-    }
-  }, [isRunning]);
+  const { isRunning } = useSimulationRunner();
 
   const hasResult = result && result.length > 0;
 
@@ -47,7 +35,6 @@ export function EditorNav({ active, modelId, simulationId }: EditorNavProps) {
           <TabsTrigger
             value="results"
             className={`w-full h-full rounded-tl-none rounded-tr-none data-[state=active]:bg-choras-dark data-[state=active]:text-choras-accent text-choras-accent/50 flex items-center justify-center bg-choras-dark/50 cursor-pointer
-            ${isCompleted && "ring-2 ring-yellow-400 shadow-lg animate-pulse bg-yellow-500/20"}
             `}
             style={{
               textOrientation: "mixed",

--- a/src/hooks/useSimulationRunner.ts
+++ b/src/hooks/useSimulationRunner.ts
@@ -16,7 +16,7 @@ import { useSimulationRunnerContext } from "@/contexts/SimulationRunnerContext";
 export function useSimulationRunner() {
   const { isRunning, setIsRunning, progress, setProgress } = useSimulationRunnerContext();
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
   const hasCheckedForRunningSimulation = useRef(false);
   const lastCheckedSimulationId = useRef<number | null>(null);
 
@@ -38,13 +38,6 @@ export function useSimulationRunner() {
     }
   }, []);
 
-  const clearResetTimeout = useCallback(() => {
-    if (resetTimeoutRef.current) {
-      clearTimeout(resetTimeoutRef.current);
-      resetTimeoutRef.current = null;
-    }
-  }, []);
-
   const cancelAndStop = useCallback(async () => {
     if (!activeSimulation?.id) {
       return;
@@ -59,7 +52,6 @@ export function useSimulationRunner() {
     }
 
     setIsRunning(false);
-    clearResetTimeout();
     setProgress(0);
     stopPolling();
   }, [activeSimulation?.id, cancelSimulation, stopPolling]);
@@ -85,12 +77,7 @@ export function useSimulationRunner() {
             getSimulationResult(activeSimulation.id);
             getSimulationsByModelId(activeSimulation.modelId);
             getImpulseResponseBySimulationId(activeSimulation.id);
-            // Reset the visual progress after a short delay; ensure we don't race with a new run
-            clearResetTimeout();
-            resetTimeoutRef.current = setTimeout(() => {
-              setProgress(0);
-              resetTimeoutRef.current = null;
-            }, 5000);
+            setProgress(0);
           } else if (currentRun.status === "Error" || currentRun.status === "Failed") {
             setIsRunning(false);
             stopPolling();
@@ -118,7 +105,6 @@ export function useSimulationRunner() {
     getSimulationResult,
     getSimulationsByModelId,
     getImpulseResponseBySimulationId,
-    clearResetTimeout,
   ]);
 
   const startSimulation = useCallback(async () => {
@@ -130,7 +116,6 @@ export function useSimulationRunner() {
     }
 
     // Ensure any previous reset timers are cleared to avoid resetting a new run's progress
-    clearResetTimeout();
     setIsRunning(true);
     setProgress(0);
 
@@ -156,7 +141,6 @@ export function useSimulationRunner() {
     patchMeshes,
     runSimulation,
     pollProgress,
-    clearResetTimeout,
   ]);
 
   useEffect(() => {
@@ -220,9 +204,8 @@ export function useSimulationRunner() {
   useEffect(() => {
     return () => {
       stopPolling();
-      clearResetTimeout();
     };
-  }, [stopPolling, clearResetTimeout]);
+  }, [stopPolling]);
 
   return {
     isRunning,


### PR DESCRIPTION
This pull request includes several bug fixes and UI consistency improvements, as well as some code cleanup and optimizations related to simulation and model management. The most important changes are grouped below by theme.

**Simulation and Model Management:**

* Ensured cache invalidation for simulations when a model is deleted by importing `simulationApi` and dispatching an additional invalidateTags call in `ModelCard.tsx`. This prevents stale simulation data after deleting a model. [[1]](diffhunk://#diff-94ad9a358cff117dd638812e32d57b91b98ab7e3a76e8800cae643b67b955f59L3-R3) [[2]](diffhunk://#diff-94ad9a358cff117dd638812e32d57b91b98ab7e3a76e8800cae643b67b955f59L31-R35)
* Updated the project version to `0.0.52` in `package.json` and added a new changelog entry summarizing these fixes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R11)

**UI Consistency and Improvements:**

* Removed colons from labels in `SimulationPicker` for a cleaner and more consistent look. [[1]](diffhunk://#diff-fbcca804b5861d2a8d3c3b52137e0ea6d4d5195e9c7abdf1758b783a31f45110L180-R180) [[2]](diffhunk://#diff-fbcca804b5861d2a8d3c3b52137e0ea6d4d5195e9c7abdf1758b783a31f45110L269-R269)
* Replaced the `CircleHelp` icon with an inline SVG for the method info dialog, removing an unnecessary import and improving icon consistency. [[1]](diffhunk://#diff-de3092eaae112870ff0a336e2f8e54f3beac0389e2d31d4650f7053dfae83369L10-R10) [[2]](diffhunk://#diff-de3092eaae112870ff0a336e2f8e54f3beac0389e2d31d4650f7053dfae83369L29-R44)

**Code Cleanup and Optimization:**

* Refactored `useSimulationRunner` and `EditorNav` to remove unused state and effect logic related to progress reset timers, simplifying the simulation runner logic and reducing unnecessary code. [[1]](diffhunk://#diff-d4d00d10a737691c9ea3853241727b1777a2057c0379ff6b60c62a95ff0c1b29L4) [[2]](diffhunk://#diff-d4d00d10a737691c9ea3853241727b1777a2057c0379ff6b60c62a95ff0c1b29L15-R14) [[3]](diffhunk://#diff-d4d00d10a737691c9ea3853241727b1777a2057c0379ff6b60c62a95ff0c1b29L50) [[4]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L19-R19) [[5]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L41-L47) [[6]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L62) [[7]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L88-L93) [[8]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L121) [[9]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L133) [[10]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L159) [[11]](diffhunk://#diff-eb7b406ef9688bcc41d90b1e8966c27e2ba68dc16443e9633093011698c15f97L223-R208)