### PR TITLE
fix: adjust stroke width for polygon in TrapezoidOutlineTab

### DIFF
--- a/src/components/features/results/TrapezoidOutlineTab.tsx
+++ b/src/components/features/results/TrapezoidOutlineTab.tsx
@@ -31,7 +31,7 @@ export function TrapezoidOutlineTab({ value, children, ...restProps }: Trapezoid
           points="0,0 1,0 95,15 95,85 1,100 0,100"
           fill="none"
           stroke="currentColor"
-          strokeWidth="2"
+          strokeWidth="1.5"
           vectorEffect="non-scaling-stroke"
           shapeRendering="crispEdges"
           className="transition-colors stroke-black/50 data-[state=active]:stroke-black"


### PR DESCRIPTION
Fix https://github.com/choras-org/frontend-v2/issues/109#issuecomment-3497260534