### PR TITLE
fix: IR Waveform to follow the Audacity waveform

### DIFF
--- a/src/components/features/results/ImpulseResponsePlayer.tsx
+++ b/src/components/features/results/ImpulseResponsePlayer.tsx
@@ -112,84 +112,64 @@ const renderFunction: (
 ) => (peaks: Array<Float32Array | number[]>, ctx: CanvasRenderingContext2D) => void =
   (color) => (channels, ctx) => {
     const { width, height } = ctx.canvas;
-    const channel = channels[0];
-    const step = 5; // Pixels per triangle
+    const channelCount = channels.length;
 
-    ctx.translate(0, height / 2);
+    ctx.clearRect(0, 0, width, height);
 
-    // Draw horizontal centerline first
-    ctx.strokeStyle = color; // Light gray
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(width, 0);
-    ctx.stroke();
+    // Draw each channel
+    channels.forEach((channel, channelIndex) => {
+      const channelHeight = height / channelCount;
+      const offsetY = channelIndex * channelHeight + channelHeight / 2;
 
-    // Draw waveform
-    ctx.strokeStyle = ctx.fillStyle;
-    ctx.lineWidth = 1;
-    ctx.lineJoin = "round";
-    ctx.lineCap = "round";
-    ctx.beginPath();
+      // Set line style
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
 
-    // Calculate how many samples per pixel
-    const samplesPerPixel = channel.length / width;
+      const amp = channelHeight / 2;
+      const length = channel.length;
+      const hScale = length ? width / length : 0;
 
-    // Analyze ALL samples without skipping for accurate IR analysis
-    for (let x = 0; x < width; x += step * 2) {
-      // Analyze the full range from current position to next position (no gaps)
-      const startSample = Math.floor(x * samplesPerPixel);
-      const endSample = Math.floor((x + step * 2) * samplesPerPixel);
+      // Draw waveform like wavesurfer.js
+      ctx.beginPath();
 
-      // Find peak in the entire region for accurate representation
-      let max = 0;
-      for (let i = startSample; i < endSample && i < channel.length; i++) {
-        const absValue = Math.abs(channel[i]);
-        if (absValue > max) max = absValue;
+      let prevX = 0;
+      let maxValue = 0;
+
+      for (let i = 0; i <= length; i++) {
+        const x = Math.round(i * hScale);
+
+        if (x > prevX) {
+          // When we move to a new pixel, draw the accumulated peak
+          const y = offsetY - maxValue * amp;
+
+          if (prevX === 0) {
+            ctx.moveTo(prevX, y);
+          } else {
+            ctx.lineTo(prevX, y);
+          }
+
+          prevX = x;
+          maxValue = 0;
+        }
+
+        // Find the value with the highest absolute magnitude, but keep its sign
+        const currentValue = channel[i] || 0;
+        if (Math.abs(currentValue) > Math.abs(maxValue)) {
+          maxValue = currentValue;
+        }
       }
 
-      // Scale to canvas height
-      const y = max * (height / 2 - 10);
+      // Final point
+      ctx.lineTo(prevX, offsetY - maxValue * amp);
+      ctx.stroke();
 
-      // Draw curved wave (upward) using bezier curve for smoother, rounder peaks
-      ctx.moveTo(x, 0);
-      ctx.bezierCurveTo(
-        x + step * 0.25,
-        y * 0.9, // First control point
-        x + step * 0.4,
-        y, // Second control point
-        x + step / 2,
-        y, // Peak
-      );
-      ctx.bezierCurveTo(
-        x + step * 0.6,
-        y, // First control point
-        x + step * 0.75,
-        y * 0.9, // Second control point
-        x + step,
-        0, // End point
-      );
-
-      // Draw curved wave (downward) using bezier curve for smoother, rounder peaks
-      ctx.moveTo(x + step, 0);
-      ctx.bezierCurveTo(
-        x + step + step * 0.25,
-        -y * 0.9, // First control point
-        x + step + step * 0.4,
-        -y, // Second control point
-        x + step + step / 2,
-        -y, // Peak
-      );
-      ctx.bezierCurveTo(
-        x + step + step * 0.6,
-        -y, // First control point
-        x + step + step * 0.75,
-        -y * 0.9, // Second control point
-        x + step * 2,
-        0, // End point
-      );
-    }
-
-    ctx.stroke();
-    ctx.closePath();
+      // Draw center line
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(0, offsetY);
+      ctx.lineTo(width, offsetY);
+      ctx.stroke();
+    });
   };

--- a/src/components/features/results/ImpulseResponsePlayer.tsx
+++ b/src/components/features/results/ImpulseResponsePlayer.tsx
@@ -129,40 +129,23 @@ const renderFunction: (
 
       const amp = channelHeight / 2;
       const length = channel.length;
-      const hScale = length ? width / length : 0;
+      const hScale = width / length;
 
-      // Draw waveform like wavesurfer.js
+      // Draw waveform - plot every single sample
       ctx.beginPath();
 
-      let prevX = 0;
-      let maxValue = 0;
+      for (let i = 0; i < length; i++) {
+        const x = i * hScale;
+        const value = channel[i] || 0;
+        const y = offsetY - value * amp;
 
-      for (let i = 0; i <= length; i++) {
-        const x = Math.round(i * hScale);
-
-        if (x > prevX) {
-          // When we move to a new pixel, draw the accumulated peak
-          const y = offsetY - maxValue * amp;
-
-          if (prevX === 0) {
-            ctx.moveTo(prevX, y);
-          } else {
-            ctx.lineTo(prevX, y);
-          }
-
-          prevX = x;
-          maxValue = 0;
-        }
-
-        // Find the value with the highest absolute magnitude, but keep its sign
-        const currentValue = channel[i] || 0;
-        if (Math.abs(currentValue) > Math.abs(maxValue)) {
-          maxValue = currentValue;
+        if (i === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
         }
       }
 
-      // Final point
-      ctx.lineTo(prevX, offsetY - maxValue * amp);
       ctx.stroke();
 
       // Draw center line


### PR DESCRIPTION
## Changelog 

fix: IR Waveform to follow the Audacity waveform

<img width="904" height="583" alt="Screenshot 2025-11-07 at 17 03 24" src="https://github.com/user-attachments/assets/da727b4d-01fa-487f-8962-20afe4f1f0e6" />
<img width="947" height="580" alt="Screenshot 2025-11-07 at 17 02 51" src="https://github.com/user-attachments/assets/212a1fd9-f29a-47cc-b4c2-d4ba90b75eb4" />
